### PR TITLE
Correct typo in help file

### DIFF
--- a/doc/fugitive-gitlab.txt
+++ b/doc/fugitive-gitlab.txt
@@ -28,7 +28,7 @@ and project/group members, you will need to create a GitLab access token
 https://gitlab.com/profile/personal_access_tokens
 with api permissions.
 
-  let g:gitlab_api_keys = {'gitlab.com', 'token', 'gitlab.mydomain.com': 'token2'}
+  let g:gitlab_api_keys = {'gitlab.com': 'token', 'gitlab.mydomain.com': 'token2'}
 
 COMMANDS                                        *fugitive-gitlab-commands*
 


### PR DESCRIPTION
A comma was mistakenly written instead of a colon in an example map literal in the help file